### PR TITLE
Function context

### DIFF
--- a/.gtksourceview-3.0/language-specs/c.lang
+++ b/.gtksourceview-3.0/language-specs/c.lang
@@ -52,6 +52,7 @@
     <style id="standard-stream"   _name="Standard stream"       map-to="def:constant"/>
     <style id="signal-name"       _name="Signal name"           map-to="def:constant"/>
     <style id="error"             _name="Error"                 map-to="def:error"/>
+    <style id="function"          _name="Function"              map-to="def:function"/>
   </styles>
 
   <definitions>
@@ -190,6 +191,15 @@
         (?![\w\.])
       </match>
     </context>
+    
+     <context id="function">
+       <match extended="true">
+         ([a-zA-Z_][a-zA-Z_0-9]*)\s*\(
+       </match>
+       <include>
+         <context id="function-name" sub-pattern="1" style-ref="function"/>
+       </include>
+     </context>
 
     <context id="keywords" style-ref="keyword">
       <keyword>asm</keyword>
@@ -337,6 +347,7 @@
         <context ref="common-defines"/>
         <context ref="standard-streams"/>
         <context ref="signals"/>
+        <context ref="function"/>
       </include>
     </context>
 

--- a/.gtksourceview-3.0/styles/atom_one_dark_theme.xml
+++ b/.gtksourceview-3.0/styles/atom_one_dark_theme.xml
@@ -54,6 +54,7 @@
 
   <!-- Identifiers -->
   <style name="def:identifier"              foreground="hue62"/>
+  <style name="def:function"                foreground="hue2"/>
 
   <!-- Statements -->
   <style name="def:statement"               foreground="hue3"/>


### PR DESCRIPTION
Add a function context to the *c.lang* specification and the *atom_one_dark_theme.xml* style.
This allows for highlighting function names inside *gtksourceview-3.0* widgets.